### PR TITLE
Relative Import Behavior when stacked with import hooks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -76,7 +76,7 @@ class _demandmod(object):
             # the right-most module instead of the left-most.
             fromlist = ['__name__'] if parent_path else []
             if level == -1:
-                mod = _origimport(path, globals, locals, fromlist)
+                mod = _origimport(path, globals, locals, fromlist, 0)
             else:
                 mod = _origimport(path, globals, locals, fromlist, level)
             assert not isinstance(mod, _demandmod)
@@ -125,7 +125,7 @@ def _demandimport(name, globals=None, locals=None, fromlist=None, level=-1):
         if not locals or name in _ignore or fromlist == ('*',):
             # these cases we can't really delay
             if level == -1:
-                return _origimport(name, globals, locals, fromlist)
+                return _origimport(name, globals, locals, fromlist, 0)
             else:
                 return _origimport(name, globals, locals, fromlist, level)
         elif not fromlist:

--- a/src/tests/test_issues.py
+++ b/src/tests/test_issues.py
@@ -86,8 +86,6 @@ class TestIssues(unittest.TestCase):
                 __import__(m.name+'.a.c', locals={'foo': 'bar'}).a.c.__name__
 
     def test_issue3_hook(self):
-        if sys.version_info[0] >= 3:
-            return
         with TestModule() as m:
             with open(os.path.join(m.path, '__init__.py'), 'a') as f:
                 f.write(import_hook)


### PR DESCRIPTION
Had an issue when demandimport was used with a sys.meta_path import hook https://gist.github.com/fried/4254e881ba90cf0d9e4f26f7da3bcceb

The hook allows for the following module:  (We have reasons for this, its not as simple as just forcing everyone to use one way or the other)
 package.lib.module
to be imported with the name
 package.module
but maintain that they are the same module object.    

Well when testing our hook with demandimport,  demandimport in python 2 was sending imports to our hook in the form  'package.lib.package' after we attempted to demand import 'package.lib.module'.      In python3 it worked as expected. 

I made the following change, and our tests passed and demain imports tests passed.   I know the level field controls absolute/relative imports in python2, and this might break some use case but i don't know what that is.
